### PR TITLE
🐛 Fix automatic pitch calculation in ScrewHole()

### DIFF
--- a/threads.scad
+++ b/threads.scad
@@ -223,7 +223,7 @@ module ClosePoints(pointarrays) {
   ];
   faces = concat(faces_bot, faces_loop, faces_top);
 
-  polyhedron(points=points, faces=faces);
+  polyhedron(points=points, faces=faces, convexity=2);
 }
 
 

--- a/threads.scad
+++ b/threads.scad
@@ -7,7 +7,7 @@
 // v2.1
 
 
-screw_resolution = 0.2;  // in mm
+screw_resolution = $fs;  // in mm
 
 
 // Provides standard metric thread pitches.

--- a/threads.scad
+++ b/threads.scad
@@ -346,6 +346,7 @@ module AugerThread(outer_diam, inner_diam, height, pitch, tooth_angle=30, tolera
 // default.
 module ScrewHole(outer_diam, height, position=[0,0,0], rotation=[0,0,0], pitch=0, tooth_angle=30, tolerance=0.4, tooth_height=0) {
   extra_height = 0.001 * height;
+  pitch = (pitch==0) ? ThreadPitch(outer_diam) : pitch;
 
   difference() {
     children();

--- a/threads.scad
+++ b/threads.scad
@@ -344,7 +344,7 @@ module AugerThread(outer_diam, inner_diam, height, pitch, tooth_angle=30, tolera
 
 // This creates a threaded hole in its children using metric standards by
 // default.
-module ScrewHole(outer_diam, height, position=[0,0,0], rotation=[0,0,0], pitch=0, tooth_angle=30, tolerance=0.4, tooth_height=0) {
+module ScrewHole(outer_diam, height, position=[0,0,0], rotation=[0,0,0], pitch=0, tooth_angle=30, tolerance=0.4, tooth_height=0, tip_height=0, tip_min_fract=0) {
   extra_height = 0.001 * height;
   pitch = (pitch==0) ? ThreadPitch(outer_diam) : pitch;
 
@@ -354,7 +354,7 @@ module ScrewHole(outer_diam, height, position=[0,0,0], rotation=[0,0,0], pitch=0
       rotate(rotation)
       translate([0, 0, -extra_height/2])
       ScrewThread(1.01*outer_diam + 1.25*tolerance, height + extra_height,
-        pitch, tooth_angle, tolerance, tooth_height=tooth_height);
+        pitch, tooth_angle, tolerance, tooth_height=tooth_height, tip_height=tip_height, tip_min_fract=tip_min_fract);
   }
 }
 


### PR DESCRIPTION
As `ScrewThread()` is called in `ScrewHole()` with scaled values for
`outer_diam`, the `ThreadPitch()` function in `ScrewThread()` outputs
non-matching values. Calculating the pitch independently fixes it.

- Fixes #1