### PR TITLE
Remove the automated Demo output

### DIFF
--- a/threads.scad
+++ b/threads.scad
@@ -625,8 +625,5 @@ module Demo() {
     }
 }
 
-
-Demo();
-
 //MetricBoltSet(6, 8, 10);
 


### PR DESCRIPTION
Removing the call to the Demo function will make it easier to add the thread.scad library to code without having to modify the library before use.