### PR TITLE
Allow ScrewHole to be called without children

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ module ScrewThread(outer_diam, height, pitch=0, tooth_angle=30, tolerance=0.4, t
 module AugerThread(outer_diam, inner_diam, height, pitch, tooth_angle=30, tolerance=0.4, tip_height=0, tip_min_fract=0)
 
 // This creates a threaded hole in its children using metric standards by
-// default.
+// default. If called without children, it creates an object suitable for
+// use with difference().
 module ScrewHole(outer_diam, height, position=[0,0,0], rotation=[0,0,0], pitch=0, tooth_angle=30, tolerance=0.4, tooth_height=0)
 
 // This creates an auger-style threaded hole in its children.

--- a/threads.scad
+++ b/threads.scad
@@ -348,7 +348,7 @@ module ScrewHole(outer_diam, height, position=[0,0,0], rotation=[0,0,0], pitch=0
   extra_height = 0.001 * height;
 
   difference() {
-    children();
+    if ($children) children();
     translate(position)
       rotate(rotation)
       translate([0, 0, -extra_height/2])


### PR DESCRIPTION
@rcolyer,

A small change allowing ScrewHole to be called without children.

This does not affect any existing use. This allows me to generate multiple screw holes in a module and subsequently `difference()` the entire union, leading to cleaner code. Imagine, a module that generates a pattern of three holes, which we reuse across multiple objects.

```
// Preexisting functionality, unchanged
ScrewHole(5, 10)
cylinder(h=10,d=10);

// New functionality
translate([10,0,0])
ScrewHole(5, 10);

// More complicated new functionality showing
// hole generation in a method
module many_holes() {
    union() {
        translate([-10,5,0])
        ScrewHole(5,10);
        translate([+10,5,0])
        ScrewHole(5,10);
        translate([0,-10,0])
        ScrewHole(5,10);
    }
}

difference() {
    cylinder(h=10,d=30);
    many_holes();
}

translate([40,0,0])
difference() {
    cube([30,30,20], center=true);
    many_holes();
}
```
